### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.3+4] - June, 7, 2022
+
+* Automated dependency updates
+
+
 ## [1.0.3+3] - May, 31, 2022
 
 * Automated dependency updates
@@ -32,4 +37,5 @@
 ## [1.0.0] - November 12th, 2021
 
 * Initial Release
+
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'grpc_pubsub'
 description: 'Wrapper client around the gRPC based APIs for Google Pub/Sub that supports streaming and retries.'
-version: '1.0.3+3'
+version: '1.0.3+4'
 homepage: 'https://github.com/peiffer-innovations/grpc_pubsub'
 
 environment: 
@@ -9,7 +9,7 @@ environment:
 dependencies: 
   grpc: '^3.0.2'
   grpc_googleapis: '^2.0.20'
-  grpc_protobuf_convert: '^2.0.0+2'
+  grpc_protobuf_convert: '^2.0.0+3'
   logging: '^1.0.2'
   meta: '^1.7.0'
   protobuf: '^2.0.1'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `grpc_protobuf_convert`: 2.0.0+2 --> 2.0.0+3


Analysis Successful

