### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.3+9] - July 19, 2022
+
+* Automated dependency updates
+
+
 ## [1.0.3+8] - July 12, 2022
 
 * Automated dependency updates
@@ -57,6 +62,7 @@
 ## [1.0.0] - November 12th, 2021
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'grpc_pubsub'
 description: 'Wrapper client around the gRPC based APIs for Google Pub/Sub that supports streaming and retries.'
-version: '1.0.3+8'
+version: '1.0.3+9'
 homepage: 'https://github.com/peiffer-innovations/grpc_pubsub'
 
 environment: 
@@ -8,8 +8,8 @@ environment:
 
 dependencies: 
   grpc: '^3.0.2'
-  grpc_googleapis: '^2.0.21'
-  grpc_protobuf_convert: '^2.0.0+5'
+  grpc_googleapis: '^2.0.22'
+  grpc_protobuf_convert: '^2.0.0+6'
   logging: '^1.0.2'
   meta: '^1.7.0'
   protobuf: '^2.1.0'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `grpc_googleapis`: 2.0.21 --> 2.0.22
  * `grpc_protobuf_convert`: 2.0.0+5 --> 2.0.0+6


Analysis Successful

