### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.3+12] - September 13, 2022
+
+* Automated dependency updates
+
+
 ## [1.0.3+11] - September 6, 2022
 
 * Automated dependency updates
@@ -72,6 +77,7 @@
 ## [1.0.0] - November 12th, 2021
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'grpc_pubsub'
 description: 'Wrapper client around the gRPC based APIs for Google Pub/Sub that supports streaming and retries.'
-version: '1.0.3+11'
+version: '1.0.3+12'
 homepage: 'https://github.com/peiffer-innovations/grpc_pubsub'
 
 environment: 
@@ -9,13 +9,13 @@ environment:
 dependencies: 
   grpc: '^3.0.2'
   grpc_googleapis: '^2.0.22'
-  grpc_protobuf_convert: '^2.0.0+7'
+  grpc_protobuf_convert: '^2.0.0+8'
   logging: '^1.0.2'
   meta: '^1.7.0'
   protobuf: '^2.1.0'
 
 dev_dependencies: 
-  test: '^1.21.5'
+  test: '^1.21.6'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `grpc_protobuf_convert`: 2.0.0+7 --> 2.0.0+8

dev_dependencies:
  * `test`: 1.21.5 --> 1.21.6


Analysis Successful

