### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.3+15] - November 1, 2022
+
+* Automated dependency updates
+
+
 ## [1.0.3+14] - October 11, 2022
 
 * Automated dependency updates
@@ -87,6 +92,7 @@
 ## [1.0.0] - November 12th, 2021
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: 'grpc_pubsub'
 description: 'Wrapper client around the gRPC based APIs for Google Pub/Sub that supports streaming and retries.'
-version: '1.0.3+14'
+version: '1.0.3+15'
 homepage: 'https://github.com/peiffer-innovations/grpc_pubsub'
 
 environment: 
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies: 
-  grpc: '^3.0.2'
+  grpc: '^3.1.0'
   grpc_googleapis: '^2.0.22'
   grpc_protobuf_convert: '^2.0.0+9'
   logging: '^1.1.0'
@@ -15,7 +15,7 @@ dependencies:
   protobuf: '^2.1.0'
 
 dev_dependencies: 
-  test: '^1.21.6'
+  test: '^1.21.7'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `grpc`: 3.0.2 --> 3.1.0

dev_dependencies:
  * `test`: 1.21.6 --> 1.21.7


Analysis Successful

