### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.3+21] - January 24, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.3+20] - January 17, 2023
 
 * Automated dependency updates
@@ -117,6 +122,7 @@
 ## [1.0.0] - November 12th, 2021
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'grpc_pubsub'
 description: 'Wrapper client around the gRPC based APIs for Google Pub/Sub that supports streaming and retries.'
-version: '1.0.3+20'
+version: '1.0.3+21'
 homepage: 'https://github.com/peiffer-innovations/grpc_pubsub'
 
 environment: 
@@ -9,7 +9,7 @@ environment:
 dependencies: 
   grpc: '^3.1.0'
   grpc_googleapis: '^2.0.22'
-  grpc_protobuf_convert: '^2.0.0+12'
+  grpc_protobuf_convert: '^2.0.0+13'
   logging: '^1.1.0'
   meta: '^1.7.0'
   protobuf: '^2.1.0'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `grpc_protobuf_convert`: 2.0.0+12 --> 2.0.0+13


Analysis Successful

