### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.4+1] - January 31, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.4] - January 24th, 2023
 
 * Flutter 3.7
@@ -127,6 +132,7 @@
 ## [1.0.0] - November 12th, 2021
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,23 +1,23 @@
 name: 'grpc_pubsub'
 description: 'Wrapper client around the gRPC based APIs for Google Pub/Sub that supports streaming and retries.'
-version: '1.0.4'
+version: '1.0.4+1'
 homepage: 'https://github.com/peiffer-innovations/grpc_pubsub'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-dependencies:
+dependencies: 
   grpc: '^3.1.0'
-  grpc_googleapis: '^2.0.22'
-  grpc_protobuf_convert: '^2.0.0+13'
-  logging: '^1.1.0'
+  grpc_googleapis: '^2.0.32'
+  grpc_protobuf_convert: '^2.0.1'
+  logging: '^1.1.1'
   meta: '^1.7.0'
   protobuf: '^2.1.0'
 
-dev_dependencies:
+dev_dependencies: 
   test: '^1.22.2'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `grpc_googleapis`: 2.0.22 --> 2.0.32
  * `grpc_protobuf_convert`: 2.0.0+13 --> 2.0.1
  * `logging`: 1.1.0 --> 1.1.1


Analysis Successful

