### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.4+6] - April 4, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.4+5] - March 28, 2023
 
 * Automated dependency updates
@@ -152,6 +157,7 @@
 ## [1.0.0] - November 12th, 2021
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'grpc_pubsub'
 description: 'Wrapper client around the gRPC based APIs for Google Pub/Sub that supports streaming and retries.'
-version: '1.0.4+5'
+version: '1.0.4+6'
 homepage: 'https://github.com/peiffer-innovations/grpc_pubsub'
 
 environment: 
@@ -9,13 +9,13 @@ environment:
 dependencies: 
   grpc: '^3.1.0'
   grpc_googleapis: '^2.0.32'
-  grpc_protobuf_convert: '^2.0.1+2'
+  grpc_protobuf_convert: '^2.0.1+3'
   logging: '^1.1.1'
   meta: '^1.8.0'
   protobuf: '^2.1.0'
 
 dev_dependencies: 
-  test: '^1.24.0'
+  test: '^1.24.1'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `grpc_protobuf_convert`: 2.0.1+2 --> 2.0.1+3

dev_dependencies:
  * `test`: 1.24.0 --> 1.24.1


Analysis Successful

