### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.5+1] - July 18, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.5] - June 17th, 2023
 
 * Dart 3.0
@@ -187,6 +192,7 @@
 ## [1.0.0] - November 12th, 2021
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,23 +1,23 @@
 name: 'grpc_pubsub'
 description: 'Wrapper client around the gRPC based APIs for Google Pub/Sub that supports streaming and retries.'
-version: '1.0.5'
+version: '1.0.5+1'
 homepage: 'https://github.com/peiffer-innovations/grpc_pubsub'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
-  grpc: '^3.1.0'
+dependencies: 
+  grpc: '^3.2.3'
   grpc_googleapis: '^2.0.32'
-  grpc_protobuf_convert: '^2.0.1+5'
+  grpc_protobuf_convert: '^2.0.2+1'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  protobuf: '^2.1.0'
+  protobuf: '^3.0.0'
 
-dev_dependencies:
-  test: '^1.24.3'
+dev_dependencies: 
+  test: '^1.24.4'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `grpc`: 3.1.0 --> 3.2.3
  * `grpc_protobuf_convert`: 2.0.1+5 --> 2.0.2+1
  * `protobuf`: 2.1.0 --> 3.0.0

dev_dependencies:
  * `test`: 1.24.3 --> 1.24.4


Error!!!
```
Resolving dependencies...


Because grpc_pubsub depends on grpc_googleapis ^2.0.32 which depends on protobuf ^2.0.1, protobuf ^2.0.1 is required.
So, because grpc_pubsub depends on protobuf ^3.0.0, version solving failed.

```

